### PR TITLE
Updated install instructions for postgresql

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ As for postgresql, visit [official guide](https://www.postgresql.org/download/li
 apt install -y postgresql-common
 /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
 apt -y install postgresql
-apt install postgresql-16-pgvector
+apt install postgresql-17-pgvector
 ```
 
 To prepare the database, we need to make some configuration.


### PR DESCRIPTION
PostgreSQL 17.0 was released on 2024-09-06, thus installation instructions need to be updated from

"apt install postgresql-16-pgvector"

to

"apt install postgresql-17-pgvector"