### PR TITLE
Upgrade to ffmpeg 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ After one has added the Jellyfin repo into their package manager's list, we can 
 
 ```bash
 apt update
-apt install jellyfin-ffmpeg6
+apt install jellyfin-ffmpeg7
 ```
 
 Finally, we soft link the Jellyfin FFmpeg to `/usr/bin/`


### PR DESCRIPTION
So, FFmpeg released its major version 7, and Jellfin followed closely. Now it is my turn.