### PR TITLE
disable jpeg-xl when building libvips

### DIFF
--- a/pre-install.sh
+++ b/pre-install.sh
@@ -281,7 +281,8 @@ build_libvips () {
     
     remove_build_folder $SOURCE
     
-    meson setup build --buildtype=release --libdir=lib -Dintrospection=disabled -Dtiff=disabled
+    # -Djpeg-xl=disabled is added because previous broken install will break libvips
+    meson setup build --buildtype=release --libdir=lib -Dintrospection=disabled -Dtiff=disabled -Djpeg-xl=disabled
     cd build
     ninja install
     ldconfig /usr/local/lib


### PR DESCRIPTION
Previous broken libjxl build will break future libvips if it is used