### PR TITLE
Add -f to post-install.sh rm command

### DIFF
--- a/post-install.sh
+++ b/post-install.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR=$PWD
 
 copy_service_files () {
     # Remove deprecated service
-    rm /etc/systemd/system/immich-microservices.service
+    rm -f /etc/systemd/system/immich-microservices.service
     # Copy new services
     cp immich-ml.service /etc/systemd/system/
     cp immich-web.service /etc/systemd/system/


### PR DESCRIPTION
Following the install steps on a fresh install, the post-install script was failing at this line due to the file not existing

![image](https://github.com/user-attachments/assets/2c28a1a8-253c-452d-972a-80883fddd040)
