### PR TITLE
Fix Debian Bookworm Build and Bump Version to v1.137.3

### DIFF
--- a/dep-debian.sh
+++ b/dep-debian.sh
@@ -2,7 +2,7 @@
 
 set -xeuo pipefail # Make my life easier
 
-# Install Dependency for Debian 12
+# Install dependencys for Debian 12
 
 # Add source
 if [ ! -d "/etc/apt/sources.list.d/immich.list" ]; then
@@ -23,26 +23,8 @@ fi
 # Update before install from new sources
 apt update
 
-# libjpeg62-turbo-dev
-apt install --no-install-recommends -y \
-        libjpeg62-turbo-dev
-## libjpeg-turbo is faster than libjpeg
-
-# Dockerfile 35
+# Install dev libraries from testing
 apt install -t testing --no-install-recommends -yqq \
-        libdav1d-dev \
         libhwy-dev \
-        libwebp-dev \
-        libio-compress-brotli-perl
-
-## Dockerfile 92
-apt install -t testing --no-install-recommends -y \
-        libio-compress-brotli-perl \
-        libwebp7 \
-        libwebpdemux2 \
-        libwebpmux3 \
-        libhwy1t64
-
-## Dockerfile 104
-# apt install -t stable --no-install-recommends -y \
-#         intel-media-va-driver
+        libsharpyuv-dev \
+        libwebp-dev

--- a/dep-intel.sh
+++ b/dep-intel.sh
@@ -10,12 +10,12 @@ TEMP_DIR=/tmp/immich-intel
 mkdir $TEMP_DIR
 cd $TEMP_DIR
 
-# Copied from immich/machine-learning/Dockerfile line 41
+# Copied from immich/machine-learning/Dockerfile line 77
 apt-get install --no-install-recommends -yqq ocl-icd-libopencl1 wget
-wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17384.11/intel-igc-core_1.0.17384.11_amd64.deb
-wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17384.11/intel-igc-opencl_1.0.17384.11_amd64.deb
-wget https://github.com/intel/compute-runtime/releases/download/24.31.30508.7/intel-opencl-icd_24.31.30508.7_amd64.deb
-wget https://github.com/intel/compute-runtime/releases/download/24.31.30508.7/libigdgmm12_22.4.1_amd64.deb
+wget -nv https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17384.11/intel-igc-core_1.0.17384.11_amd64.deb
+wget -nv https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17384.11/intel-igc-opencl_1.0.17384.11_amd64.deb
+wget -nv https://github.com/intel/compute-runtime/releases/download/24.31.30508.7/intel-opencl-icd_24.31.30508.7_amd64.deb
+wget -nv https://github.com/intel/compute-runtime/releases/download/24.31.30508.7/libigdgmm12_22.4.1_amd64.deb
 dpkg -i *.deb
 
 # Clean up

--- a/install.env
+++ b/install.env
@@ -1,5 +1,5 @@
 # Installation settings
-REPO_TAG=v1.135.3
+REPO_TAG=v1.137.3
 INSTALL_DIR=/home/immich
 UPLOAD_DIR=/home/immich/upload
 isCUDA=false

--- a/install.sh
+++ b/install.sh
@@ -355,7 +355,9 @@ install_immich_machine_learning () {
     if [ $isCUDA = true ]; then
         poetry install --no-root --extras cuda
     elif [ $isCUDA = "openvino" ]; then
-        poetry install --no-root --extras openvino
+        poetry add "numpy<2"
+        poetry update --lock
+        poetry install --no-root --extras openvino    
     elif [ $isCUDA = "rocm" ]; then
         # https://rocm.docs.amd.com/projects/radeon/en/latest/docs/install/native_linux/install-onnx.html
         pip3 install onnxruntime-rocm -f https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4.1/

--- a/install.sh
+++ b/install.sh
@@ -287,11 +287,11 @@ install_immich_web_server () {
     cp -a server/node_modules server/dist server/bin $INSTALL_DIR_app/
     cp -a web/build $INSTALL_DIR_app/www
     cp -a server/resources server/package.json server/package-lock.json $INSTALL_DIR_app/
-    cp -a server/start*.sh $INSTALL_DIR_app/
+    cp -a server/bin/start*.sh $INSTALL_DIR_app/
     cp -a LICENSE $INSTALL_DIR_app/
     cp -a i18n $INSTALL_DIR/
     cp -a open-api/typescript-sdk $INSTALL_DIR_app/
-    cp -a docker/scripts/get-cpus.sh $INSTALL_DIR_app/
+    cp -a server/bin/get-cpus.sh $INSTALL_DIR_app/
     cd ..
 }
 

--- a/post-install.sh
+++ b/post-install.sh
@@ -11,8 +11,8 @@ copy_service_files () {
     # Remove deprecated service
     rm -f /etc/systemd/system/immich-microservices.service
     # Copy new services
-    cp --update=none immich-ml.service /etc/systemd/system/
-    cp --update=none immich-web.service /etc/systemd/system/
+    cp --update immich-ml.service /etc/systemd/system/
+    cp --update immich-web.service /etc/systemd/system/
 }
 
 copy_service_files


### PR DESCRIPTION
This patchset re-establishes dependency compatibility with Debian Bookworm and updates the version to v1.137.3, effectively closing pull request [#110](https://github.com/loeeeee/immich-in-lxc/pull/110).